### PR TITLE
Fix Flaky Test - VersionsTest

### DIFF
--- a/src/main/resources/versions.properties
+++ b/src/main/resources/versions.properties
@@ -65,6 +65,7 @@ firefox55=0.20.0
 
 # Browser: Opera - Driver: operadriver
 # Source: https://github.com/operasoftware/operachromiumdriver/releases
+opera73=87.0.4280.67
 opera72=86.0.4240.80
 opera71=85.0.4183.102
 opera70=84.0.4147.89

--- a/src/main/resources/versions.properties
+++ b/src/main/resources/versions.properties
@@ -94,8 +94,8 @@ opera46=2.29
 
 # Browser: Microsoft Edge - Driver: msedgedriver
 # Source: https://developer.microsoft.com/en-us/microsoft-edge/tools/webdriver/
-edge89=89.0.719.0
-edge88=88.0.702.0
+edge89=89.0.726.0
+edge88=88.0.705.15
 edge87=87.0.669.0
 edge86=86.0.622.69
 edge85=85.0.564.70

--- a/src/main/resources/versions.properties
+++ b/src/main/resources/versions.properties
@@ -2,6 +2,7 @@
 
 # Browser: Google Chrome and Chromium - Driver: chromedriver
 # Source: http://chromedriver.chromium.org/downloads
+chrome88=88.0.4324.27
 chrome87=87.0.4280.88
 chrome86=86.0.4240.22
 chrome85=85.0.4183.87

--- a/src/main/resources/versions.properties
+++ b/src/main/resources/versions.properties
@@ -95,7 +95,7 @@ opera46=2.29
 
 # Browser: Microsoft Edge - Driver: msedgedriver
 # Source: https://developer.microsoft.com/en-us/microsoft-edge/tools/webdriver/
-edge89=89.0.726.0
+edge89=89.0.723.0
 edge88=88.0.705.15
 edge87=87.0.669.0
 edge86=86.0.622.69


### PR DESCRIPTION
The test
`io.github.bonigarcia.wdm.test.versions.VersionsTest.testChromeDriverVersions`
is flaky and the goal is to remove that flakiness.

Flaky Test Reason:
`WebDriverManager`was trying to get drivers from Github using the driver URL. GitHub servers will return an HTTP 403 error when several consecutive requests are made by WebDriverManager. Unfortunately, this is what happened in VersionsTest: since in this test we are testing driver versions for different web drivers/browsers, we need to get the latest drivers for all of them. Since some of the drivers (geckodriver and operadriver) are hosted on GitHub, we are sending several consecutive requests to the GitHub servers when we're running this test, which results in some requests being rejected (HTTP 403) by the GitHub servers, and therefore the flaky tests. This is also a known issue to this project (see Known Issue).

Types of changes
Using WireMock to Mock the server and test the HTTP request, thus the request will not be rejected anymore.